### PR TITLE
[41기 윤지수] Add : signUp 레이아웃 추가(브랜치 재생성)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,12 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Market GGoGi</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Lobster&family=Noto+Sans+KR:wght@100;300;400;500;700;900&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/src/pages/SignUp/SignUp.js
+++ b/src/pages/SignUp/SignUp.js
@@ -1,8 +1,237 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import './SignUp.scss';
 
 const SignUp = () => {
-  return <div>SignUp</div>;
+  const [inputValues, setInputValues] = useState({
+    email: '',
+    userName: '',
+    pwd: '',
+    confirmPwd: '',
+    address: '',
+    phone: '',
+    birthYear: '',
+    birthMonth: '',
+    birthDay: '',
+  });
+
+  const { email, userName, pwd, confirmPwd, address, phone } = inputValues;
+
+  const [errorMsg, setErrorMsg] = useState({
+    emailError: '',
+    pwdError: '',
+    confirmPwdError: '',
+    userNameError: '',
+    phoneError: '',
+  });
+
+  const { emailError, pwdError, confirmPwdError, userNameError, phoneError } =
+    errorMsg;
+
+  const hadnleValues = (e) => {
+    const { name, value } = e.target;
+    setInputValues({ ...inputValues, [name]: value });
+  };
+
+  const { birthYear, birthMonth, birthDay } = inputValues;
+  const birthdate = birthYear.slice(-2) + birthMonth + birthDay;
+
+  console.log(email, userName, birthdate, phone, address, pwd, confirmPwd);
+
+  // useEffect(() => {
+  const onClickSignUp = (e) => {
+    e.preventDefault();
+    fetch('http://10.58.52.143:3000/users/signup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json; charset=utf-8' },
+      body: JSON.stringify({
+        email: email,
+        name: userName,
+        password: pwd,
+        address: address,
+        phone: phone,
+        birthdate: birthdate,
+      }),
+    })
+      .then((response) => response.json())
+      .then((result) => console.log(result));
+  };
+  // }, []);
+
+  return (
+    <div className="signUp">
+      <h1 className="title">회원가입</h1>
+      <div className="criticalItems">
+        <span className="star">* </span>
+        <span className="caution">필수입력사항</span>
+      </div>
+      <hr className="line" />
+      <form onChange={hadnleValues}>
+        <div className="signUpSection">
+          <div className="nameSection">
+            <label htmlFor="email">
+              이메일<span className="star">*</span>
+            </label>
+          </div>
+          <div className="inputSection">
+            <input
+              className="inputValue"
+              name="email"
+              type="email"
+              defaultValue={email}
+              placeholder="이메일을 입력해주세요"
+            />
+            <p className="error">{emailError}</p>
+          </div>
+          <div className="btnSection">
+            <button className="comfirmRepetition">중복확인</button>
+          </div>
+        </div>
+        <div className="signUpSection">
+          <div className="nameSection">
+            <label htmlFor="pwd">
+              비밀번호<span className="star">*</span>
+            </label>
+          </div>
+          <div className="inputSection">
+            <input
+              className="inputValue"
+              name="pwd"
+              type="password"
+              defaultValue={pwd}
+              placeholder="비밀번호를 입력해주세요"
+            />
+            <p className="error">{pwdError}</p>
+          </div>
+          <div className="btnSection">
+            <div className="none" />
+          </div>
+        </div>
+        <div className="signUpSection">
+          <div className="nameSection">
+            <label htmlFor="confirmPwd">
+              비밀번호확인<span className="star">*</span>
+            </label>
+          </div>
+          <div className="inputSection">
+            <input
+              className="inputValue"
+              name="confirmPwd"
+              type="password"
+              defaultValue={confirmPwd}
+              placeholder="비밀번호를 한 번 더 입력해주세요"
+            />
+            <p className="error">{confirmPwdError}</p>
+          </div>
+          <div className="btnSection">
+            <div className="none" />
+          </div>
+        </div>
+        <div className="signUpSection">
+          <div className="nameSection">
+            <label htmlFor="name">
+              이름<span className="star">*</span>
+            </label>
+          </div>
+          <div className="inputSection">
+            <input
+              className="inputValue"
+              name="userName"
+              type="text"
+              defaultValue={userName}
+              placeholder="이름을 입력해주세요"
+            />
+            <p className="error">{userNameError}</p>
+          </div>
+          <div className="btnSection">
+            <div className="none" />
+          </div>
+        </div>
+        <div className="signUpSection">
+          <div className="nameSection">
+            <label htmlFor="phone">
+              휴대폰<span className="star">*</span>
+            </label>
+          </div>
+          <div className="inputSection">
+            <input
+              className="inputValue"
+              name="phone"
+              type="tel"
+              defaultValue={phone}
+              placeholder="숫자만 입력해주세요"
+            />
+            <p className="error">{phoneError}</p>
+          </div>
+          <div className="btnSection">
+            <button className="getCode">인증번호받기</button>
+          </div>
+        </div>
+        <div className="signUpSection">
+          <div className="nameSection">
+            <label htmlFor="address">
+              주소<span className="star">*</span>
+            </label>
+          </div>
+          <div className="inputSection">
+            <input
+              className="inputValue"
+              name="address"
+              type="text"
+              defaultValue={address}
+              placeholder="주소를 입력해주세요"
+            />
+            <p className="notifyAddress">
+              배송지에 따라 상품 정보가 달라질 수 있습니다.
+            </p>
+          </div>
+          <div className="btnSection">
+            <div className="none" />
+          </div>
+        </div>
+        <div className="signUpSection">
+          <div className="nameSection">
+            <label htmlFor="address">생년월일</label>
+          </div>
+          <div className="inputSection">
+            <div className="birthWrapper">
+              <input
+                className="inputValue inputBirth"
+                name="birthYear"
+                type="text"
+                defaultValue={birthYear}
+                placeholder="YYYY"
+              />
+              /
+              <input
+                className="inputValue inputBirth"
+                name="birthMonth"
+                type="text"
+                defaultValue={birthMonth}
+                placeholder="MM"
+              />
+              /
+              <input
+                className="inputValue inputBirth"
+                name="birthDay"
+                type="text"
+                defaultValue={birthDay}
+                placeholder="DD"
+              />
+            </div>
+          </div>
+          <div className="btnSection">
+            <div className="none" />
+          </div>
+        </div>
+        <hr className="line" />
+        <div className="signUpBtnSection">
+          <button type="submit" className="signupBtn" onClick={onClickSignUp}>
+            가입하기
+          </button>
+        </div>
+      </form>
+    </div>
+  );
 };
 
 export default SignUp;

--- a/src/pages/SignUp/SignUp.scss
+++ b/src/pages/SignUp/SignUp.scss
@@ -1,0 +1,127 @@
+@import './../../styles/variables.scss';
+
+.signUp {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  margin: 50px 0 60px 0;
+
+  .title {
+    margin-bottom: 50px;
+    font-size: 28px;
+    font-weight: 500;
+  }
+
+  .criticalItems {
+    text-align: right;
+    font-size: 12px;
+    width: 640px;
+  }
+
+  .star {
+    color: $highlight-color;
+  }
+
+  .line {
+    width: 640px;
+    border: 1px solid #333333;
+  }
+
+  .signUpSection {
+    display: flex;
+    align-items: center;
+    width: 640px;
+    padding: 10px 20px;
+
+    &:nth-child(7) {
+      margin-top: 20px;
+    }
+
+    .nameSection {
+      width: 139px;
+      text-align: left;
+    }
+  }
+
+  .inputSection {
+    margin-right: 10px;
+    height: 48px;
+    font-size: 14px;
+
+    .inputValue {
+      width: 333px;
+      height: 46px;
+      padding: 0 11px 1px 15px;
+      font-size: 14px;
+    }
+
+    .error,
+    .notifyAddress {
+      text-indent: 10px;
+      font-size: 12px;
+    }
+
+    .error {
+      color: red;
+    }
+
+    .notifyAddress {
+      margin: 15px 0;
+      color: $border-color;
+    }
+
+    .birthWrapper {
+      border: 1px solid $border-color;
+      border-radius: 3px;
+    }
+
+    .inputBirth {
+      width: 96px;
+      text-align: center;
+      border: none;
+    }
+  }
+
+  .btnSection {
+    width: 120px;
+
+    button,
+    .none {
+      width: 100%;
+      height: 44px;
+    }
+
+    .comfirmRepetition,
+    .getCode {
+      color: $basic-color;
+      background-color: white;
+      border: 1px solid $basic-color;
+      border-radius: 3px;
+      cursor: pointer;
+    }
+  }
+
+  .radioSection {
+    display: flex;
+    justify-content: space-around;
+    width: 50%;
+  }
+
+  .signUpBtnSection {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+    padding: 40px 0;
+
+    .signupBtn {
+      width: 240px;
+      height: 56px;
+      background-color: $basic-color;
+      color: white;
+      border-radius: 3px;
+      border: none;
+      cursor: pointer;
+    }
+  }
+}

--- a/src/styles/common.scss
+++ b/src/styles/common.scss
@@ -1,3 +1,22 @@
 * {
   box-sizing: border-box;
+  font-family: 'Lobster', cursive;
+  font-family: 'Noto Sans KR', sans-serif;
+}
+
+$basic-color: #5f0080;
+$highlight-color: #fa622f;
+$border-color: #666666;
+
+@mixin flexRow($justify, $align) {
+  display: flex;
+  justify-content: $justify;
+  align-items: $align;
+}
+
+@mixin flexColumn($justify, $align) {
+  display: flex;
+  flex-direction: column;
+  justify-content: $justify;
+  align-items: $align;
 }

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -1,0 +1,16 @@
+$basic-color: #5f0080;
+$highlight-color: #fa622f;
+$border-color: #666666;
+
+@mixin flexRow($justify, $align) {
+  display: flex;
+  justify-content: $justify;
+  align-items: $align;
+}
+
+@mixin flexColumn($justify, $align) {
+  display: flex;
+  flex-direction: column;
+  justify-content: $justify;
+  align-items: $align;
+}


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 회원가입 레이아웃 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
- scss와 Mixin, form을 활용하여 회원가입 화면 구현
** main에서 브랜치를 생성하지 않고, login 브랜치에서 signup 브랜치를 만들어서 signup 브랜치 삭제 후 재생성했습니다.
기존에 주신 리뷰 반영해서 수정 후 다시 push 하겠습니다!

2. 로그인 데이터 처리 (예시 - 백엔드)
- 조건문과 정규식을 이용한 email과 password 유효성 검사를 진행
- 유효섬 검사를 통과하지 못 할 경우 에러 메시지를 반환 예외 처리 구현

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
회원가입 화면에 scss 를 적용하던 중 레이아웃이 틀어지는 것을 보고, 사전에 마켓컬리 사이트를 보고 철저하게 레이아웃을 구성 후 작업했어야 했다는 아쉬움이 있었습니다. 그리고 레이아웃 코드가 너무 길어서 코드를 단순화하는 작업을 나중에 해보고 싶습니다!

<br />

## :: 기타 질문 및 특이 사항
- 함수 로직이 너무 긴 것 같습니다. 좀 더 효율적인 방법이 없을지 궁금합니다.(예시) 


